### PR TITLE
Code factoring for Apache Spark PR 24076

### DIFF
--- a/core/src/main/scala/org/apache/spark/status/api/v1/api.scala
+++ b/core/src/main/scala/org/apache/spark/status/api/v1/api.scala
@@ -391,11 +391,3 @@ case class ThreadStackTrace(
     val blockedByLock: String,
     val holdingLocks: Seq[String])
 
-class ExecutionData (val id : Long,
-    val status: String,
-    val description: String,
-    val submissionTime: String,
-    val duration: String,
-    val runningJobs: Seq[Int],
-    val successJobs: Seq[Int],
-    val failedJobs: Seq[Int])

--- a/sql/core/src/main/scala/org/apache/spark/status/api/v1/api.scala
+++ b/sql/core/src/main/scala/org/apache/spark/status/api/v1/api.scala
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.status.api.v1
+
+class ExecutionData (val id : Long,
+    val status: String,
+    val description: String,
+    val submissionTime: String,
+    val duration: String,
+    val runningJobIds: Seq[Int],
+    val successJobIds: Seq[Int],
+    val failedJobIds: Seq[Int])


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. move ExecutionData to SQL module
2. rename `runningJobs` as `runningJobIds`. Rename `successJobs` and `failedJobs` as well.
3. Refactor the looping

## How was this patch tested?

Manual check 
